### PR TITLE
add Download Path option for FireFox and Safari

### DIFF
--- a/AddToTransmission-Firefox/content/options.xul
+++ b/AddToTransmission-Firefox/content/options.xul
@@ -40,6 +40,7 @@
 			<preference id="add-to-transmission-addpaused" name="extensions.addtotransmission.addpaused" type="bool"/>
 			<preference id="add-to-transmission-alllinks" name="extensions.addtotransmission.alllinks" type="bool"/>
 			<preference id="add-to-transmission-url" name="extensions.addtotransmission.url" type="string" />
+			<preference id="add-to-transmission-path" name="extensions.addtotransmission.path" type="string" />
 			<preference id="add-to-transmission-username" name="extensions.addtotransmission.username" type="string" />
 			<preference id="add-to-transmission-placement" name="extensions.addtotransmission.placement" type="string" />
 			<preference id="add-to-transmission-troubleshooting" name="extensions.addtotransmission.troubleshooting" type="bool"/>
@@ -57,6 +58,10 @@
 					<row>
 						<label control="url" value="URL"/>
 						<textbox id="url" preference="add-to-transmission-url" placeholder="http://127.0.0.1:9091/transmission/rpc" />
+					</row>
+					<row>
+						<label control="path" value="Download Path"/>
+						<textbox id="path" preference="add-to-transmission-path" />
 					</row>
 					<row>
 						<label control="username" value="&username;"/>

--- a/AddToTransmission-Firefox/content/overlay.js
+++ b/AddToTransmission-Firefox/content/overlay.js
@@ -7,10 +7,11 @@ function AddToTransmissionTorrent(info) {
     var that = this;
     // Add paused? defaults to YES!
     var addPaused = that.prefManager.getBoolPref("extensions.addtotransmission.addpaused");
+    var downloadDir = that.prefManager.getCharPref("extensions.addtotransmission.path");
 
     if (that.info.magnet) {
       // Send the magnet link
-      that.upload(JSON.stringify({method:"torrent-add", arguments:{filename:that.info.href, paused:addPaused}}));
+      that.upload(JSON.stringify({method:"torrent-add", arguments:{filename:that.info.href, paused:addPaused, "download-dir":downloadDir}}));
     } else {
       // Try to download the torrent file
       this.showText('downloadingString');
@@ -23,7 +24,7 @@ function AddToTransmissionTorrent(info) {
             // Base64 encode the metadata
             var metainfo = that.encodeBinary(request.responseText); 
           
-            that.upload(JSON.stringify({method:"torrent-add", arguments:{metainfo:metainfo, paused:addPaused}}));
+            that.upload(JSON.stringify({method:"torrent-add", arguments:{metainfo:metainfo, paused:addPaused, "download-dir":downloadDir}}));
           }
         }
       

--- a/AddToTransmission-Firefox/defaults/preferences/pref.js
+++ b/AddToTransmission-Firefox/defaults/preferences/pref.js
@@ -1,6 +1,7 @@
 pref("extensions.addtotransmission.addpaused", true);
 pref("extensions.addtotransmission.alllinks", false);
 pref("extensions.addtotransmission.username", "");
+pref("extensions.addtotransmission.path", "");
 pref("extensions.addtotransmission.url", "http://127.0.0.1:9091/transmission/rpc");
 pref("extensions.addtotransmission.placement", "t");
 pref("extensions.addtotransmission.troubleshooting", false);

--- a/AddToTransmission.safariextension/Settings.plist
+++ b/AddToTransmission.safariextension/Settings.plist
@@ -14,6 +14,16 @@
 	</dict>
 	<dict>
 		<key>DefaultValue</key>
+		<string></string>
+		<key>Key</key>
+		<string>path</string>
+		<key>Title</key>
+		<string>Download Path</string>
+		<key>Type</key>
+		<string>TextField</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
 		<string>admin</string>
 		<key>Key</key>
 		<string>username</string>

--- a/AddToTransmission.safariextension/global.html
+++ b/AddToTransmission.safariextension/global.html
@@ -67,10 +67,13 @@
 				if (safari.extension.settings.getItem("addpaused") != null) {
 					addPaused = safari.extension.settings.addpaused;
 				}
-				
+				var downloadDir = "";
+				if (safari.extension.settings.getItem("path") != null) {
+					downloadDir = safari.extension.settings.path;
+				}
 				if (that.info.magnet) {
 					// Send the magnet link
-					that.upload(JSON.stringify({method:"torrent-add", arguments:{filename:that.info.href, paused:addPaused}}));
+					that.upload(JSON.stringify({method:"torrent-add", arguments:{filename:that.info.href, paused:addPaused, "download-dir":downloadDir}}));
 				} else {
 					// Try to download the torrent file
 					that.showText("Downloading");
@@ -82,7 +85,7 @@
 							if (request.readyState == 4) {
 								// Base64 encode the metadata
 								var metainfo = Base64.encodeBinary(request.responseText); 
-								that.upload(JSON.stringify({method:"torrent-add", arguments:{metainfo:metainfo, paused:addPaused}}));
+								that.upload(JSON.stringify({method:"torrent-add", arguments:{metainfo:metainfo, paused:addPaused, "download-dir":downloadDir}}));
 							}
 						}
 					


### PR DESCRIPTION
this will add option to specify download location for the torrent. if left blank transmission will use what it has.

you might be interested in it, if not... no harm done :)

EDIT: added option to safari extension as well 
